### PR TITLE
refactor: prevent layoutshift in theme selector

### DIFF
--- a/components/ui/theme-selector.tsx
+++ b/components/ui/theme-selector.tsx
@@ -46,12 +46,9 @@ export function ThemeSelector({ variant = "black" }: ThemeSelectorProps) {
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
-  if (!mounted) {
-    return null;
-  }
-
-  const CurrentThemeIcon =
-    THEMELIST.find((t) => t.value === theme)?.icon || SunIcon;
+  const CurrentThemeIcon = mounted
+    ? (THEMELIST.find((t) => t.value === theme)?.icon ?? SunIcon)
+    : SunIcon;
 
   return (
     <div ref={containerRef} className="relative inline-block">
@@ -61,9 +58,10 @@ export function ThemeSelector({ variant = "black" }: ThemeSelectorProps) {
           "inline-flex items-center justify-center gap-1 rounded-lg p-2",
           variant === "black" && "text-black dark:text-white",
           variant === "orange" && "text-primary-400",
+          !mounted && "animate-pulse",
         )}
       >
-        <CurrentThemeIcon className="h-5 w-5" />
+        <CurrentThemeIcon className={cn("h-5 w-5")} />
         <ChevronDownIcon
           className={cn(
             "h-5 w-5 transition-transform duration-200",
@@ -72,7 +70,7 @@ export function ThemeSelector({ variant = "black" }: ThemeSelectorProps) {
         />
       </button>
 
-      {isOpen && (
+      {mounted && isOpen && (
         <div
           ref={popoverRef}
           className={cn(


### PR DESCRIPTION
### Description
- related https://github.com/notionpresso/docs/pull/22#discussion_r1825244414
- I reflected the review feedback to prevent layout shift in theme selector

### Review Point
1. 
**[AS-IS]**
- In the existing code, when the component is initially rendered, there is an empty space that suddenly shows the icon once it is mounted. This can cause layout shift.
```ts
if (!mounted) {
    return null;
}
```
**[TO-BE]**
```ts
  const CurrentThemeIcon = mounted
    ? (THEMELIST.find((t) => t.value === theme)?.icon ?? SunIcon)
    : SunIcon;
```
- When `mounted` is **false** → SunIcon
- When `mounted` is **true** and a matching icon for the theme is found → the corresponding icon
- When `mounted` is **true** and no matching icon for the theme is found → SunIcon (to prevent undefined)


2.
Theme Selector vs Language Selector
- ThemeSelector relies on client system settings or browser APIs like localStorage, 
- while LanguageSelector uses URL paths, which are accessible from both the server and client. 
- Therefore, ThemeSelector needs to manage mounting, whereas LanguageSelector does not.