### PR TITLE
feat: add 'get started', 'read the docs' buttons

### DIFF
--- a/components/landing/hero.tsx
+++ b/components/landing/hero.tsx
@@ -2,49 +2,72 @@
 
 import { cn } from "@/lib/utils";
 import { motion } from "framer-motion";
+import { ArrowRightIcon } from "@heroicons/react/24/solid";
+import { useRouter } from "next/navigation";
 
 export function LandingHero() {
+  const router = useRouter();
+
   return (
-    <section className="relative min-h-screen bg-primary-500 overflow-hidden dark:bg-black">
-      <div className="container mx-auto px-4">
-        <div className="flex flex-col items-center justify-center min-h-screen text-white dark:text-primary-400">
-          <motion.h1
-            className="text-display text-center mb-4"
+    <section
+      className={cn(
+        "relative min-h-screen overflow-hidden",
+        "bg-primary-500 dark:bg-black",
+      )}
+    >
+      <div className={cn("container mx-auto px-4")}>
+        <div
+          className={cn(
+            "flex flex-col items-center justify-center min-h-screen",
+            "text-white dark:text-primary-400",
+          )}
+        >
+          <motion.div
+            className={cn("flex flex-col items-center")}
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6 }}
           >
-            Just a cup of coffee
-            <br />
-            with NotionPresso
-          </motion.h1>
+            <h1 className={cn("text-display text-center mb-8")}>
+              Just a cup of coffee
+              <br />
+              with NotionPresso
+            </h1>
+
+            <div className={cn("flex flex-col sm:flex-row gap-4 mt-8")}>
+              <motion.button
+                className={cn(
+                  "px-8 py-4 rounded-lg font-bold min-w-[200px]",
+                  "flex items-center justify-center gap-2",
+                  "bg-white text-primary-500",
+                  "hover:bg-primary-50 transition-colors",
+                )}
+                onClick={() => router.push("/tutorial")}
+                whileHover={{ scale: 1.02 }}
+                whileTap={{ scale: 0.98 }}
+              >
+                Get Started
+                <ArrowRightIcon className={cn("w-4 h-4")} />
+              </motion.button>
+
+              <motion.button
+                className={cn(
+                  "px-8 py-4 rounded-lg font-bold min-w-[200px]",
+                  "flex items-center justify-center gap-2",
+                  "bg-transparent border-2 border-white",
+                  "hover:bg-white/10 transition-colors",
+                )}
+                onClick={() => router.push("/docs")}
+                whileHover={{ scale: 1.02 }}
+                whileTap={{ scale: 0.98 }}
+              >
+                Read the Docs
+                <ArrowRightIcon className={cn("w-4 h-4")} />
+              </motion.button>
+            </div>
+          </motion.div>
         </div>
       </div>
-
-      <motion.div
-        className="absolute bottom-8 left-1/2 -translate-x-1/2"
-        animate={{
-          y: [0, 10, 0],
-        }}
-        transition={{
-          duration: 2,
-          repeat: Infinity,
-          ease: "easeInOut",
-        }}
-      >
-        <svg
-          width="24"
-          height="24"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          className={cn("text-white dark:text-primary-400")}
-        >
-          <path d="M7 13L12 18L17 13" />
-          <path d="M7 6L12 11L17 6" />
-        </svg>
-      </motion.div>
     </section>
   );
 }


### PR DESCRIPTION
### Description
- add 'get started', 'read the docs' buttons

### Review Point
- The plan was to include a 3D model on the landing page, but since I couldn't find a satisfactory 3D model, I am looking to revise the plan.

### Screenshot
https://github.com/user-attachments/assets/71d855f6-49f5-4460-a951-719afb190c74

