### PR TITLE
fix: align text to center

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -11,6 +11,7 @@
 
 html,
 body {
+  overflow-y: scroll;
   height: 100%;
 }
 

--- a/components/landing/hero.tsx
+++ b/components/landing/hero.tsx
@@ -14,7 +14,7 @@ export function LandingHero() {
         "relative overflow-hidden",
         "bg-primary-500 dark:bg-black",
         "flex items-center",
-        "h-[calc(100vh-80px)]",
+        "h-[calc(100dvh-72px)] sm:h-[calc(100dvh-80px)]",
       )}
     >
       <div className={cn("container mx-auto px-4")}>
@@ -30,7 +30,7 @@ export function LandingHero() {
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6 }}
           >
-            <h1 className={cn("text-display text-center mb-8")}>
+            <h1 className={cn("text-h2 sm:text-display text-center mb-8")}>
               Just a cup of coffee
               <br />
               with NotionPresso

--- a/components/landing/hero.tsx
+++ b/components/landing/hero.tsx
@@ -11,14 +11,16 @@ export function LandingHero() {
   return (
     <section
       className={cn(
-        "relative min-h-screen overflow-hidden",
+        "relative overflow-hidden",
         "bg-primary-500 dark:bg-black",
+        "flex items-center",
+        "h-[calc(100vh-80px)]",
       )}
     >
       <div className={cn("container mx-auto px-4")}>
         <div
           className={cn(
-            "flex flex-col items-center justify-center min-h-screen",
+            "flex flex-col items-center justify-center",
             "text-white dark:text-primary-400",
           )}
         >


### PR DESCRIPTION
### Description
- close #29 
- align text to center
- prevent layout shift caused by scroll

|AS IS|TO BE|
|---|---|
|<img width="480" alt="image" src="https://github.com/user-attachments/assets/38f931e3-e0eb-431e-ba21-6826b2f1c407">|<img width="480" alt="image" src="https://github.com/user-attachments/assets/363a1d2f-65fb-414d-956e-3ac6c6804e33">|

### Review Point
1.
```ts
    <section
      className={cn(
        "relative overflow-hidden",
        "bg-primary-500 dark:bg-black",
        "flex items-center", // centers the content
        "h-[calc(100dvh-72px)] sm:h-[calc(100dvh-80px)]", //  calculates the height (consider mobile size)
      )}
    >
...
```

2.
I referred to the article [Preventing the Layout Shift Caused by Scrollbars](https://dev.to/rashidshamloo/preventing-the-layout-shift-caused-by-scrollbars-2flp) and added `overflow-y: scroll;` to the global CSS to prevent layout shift.