### PR TITLE
fix: update link path in navigation button

### DIFF
--- a/components/docs/navigation-button.tsx
+++ b/components/docs/navigation-button.tsx
@@ -19,7 +19,7 @@ export default function NavigationButton({
   return (
     <Link
       className="block w-full border cursor-pointer border-black p-1 sm:p-2 rounded-sm hover:bg-black hover:text-white dark:border-gray-500 dark:hover:bg-black dark:hover:text-white text-sm sm:text-base"
-      href={`/${lang}/guide/${document.group}/${document.slug}`}
+      href={`/${lang}/docs/${document.group}/${document.slug}`}
     >
       {direction === "prev" ? (
         <div className="flex items-center gap-5 h-16">

--- a/lib/mdx.ts
+++ b/lib/mdx.ts
@@ -67,7 +67,7 @@ export function getDocumentBySlug(
   slug: string,
   allDocuments: Document[],
 ): DocumentData {
-  const notFoundDocument: DocumentData = {
+  const NOT_FOUND_DOCUMENT: DocumentData = {
     slug: "",
     content: "<p>Document not found</p>",
     title: "Not Found",
@@ -77,7 +77,7 @@ export function getDocumentBySlug(
   };
 
   if (!lang || !group || !slug) {
-    return notFoundDocument;
+    return NOT_FOUND_DOCUMENT;
   }
 
   // Filter documents in the same group and sort them if necessary
@@ -86,16 +86,32 @@ export function getDocumentBySlug(
   const currentIndex = documentsInGroup.findIndex((doc) => doc.slug === slug);
 
   if (currentIndex === -1) {
-    return notFoundDocument;
+    return NOT_FOUND_DOCUMENT;
   }
 
   const document = documentsInGroup[currentIndex];
-  const prevDocument =
+
+  let prevDocument =
     currentIndex > 0 ? documentsInGroup[currentIndex - 1] : null;
-  const nextDocument =
+  let nextDocument =
     currentIndex < documentsInGroup.length - 1
       ? documentsInGroup[currentIndex + 1]
       : null;
+
+  const allGroups = Array.from(new Set(allDocuments.map((doc) => doc.group)));
+  const currentGroupIndex = allGroups.indexOf(group);
+
+  if (!prevDocument && currentGroupIndex > 0) {
+    const prevGroup = allGroups[currentGroupIndex - 1];
+    const prevGroupDocs = allDocuments.filter((doc) => doc.group === prevGroup);
+    prevDocument = prevGroupDocs[prevGroupDocs.length - 1];
+  }
+
+  if (!nextDocument && currentGroupIndex < allGroups.length - 1) {
+    const nextGroup = allGroups[currentGroupIndex + 1];
+    const nextGroupDocs = allDocuments.filter((doc) => doc.group === nextGroup);
+    nextDocument = nextGroupDocs[0];
+  }
 
   return {
     ...document,


### PR DESCRIPTION
### Description
- close #30 
- update link path in navigation button
- When the group changes, the documents of the new group should be displayed.

### ScreenShot
https://github.com/user-attachments/assets/cacf094f-97a7-475e-99ed-6a65e3316b8b
- navigation button works well.

<img width="880" alt="image" src="https://github.com/user-attachments/assets/d6f6eff1-3928-45d8-b000-f7fe75898dc0">

- The next document is visible when moving to the next group.
