### PR TITLE
prevent scrolling when mobile menu open

### DIFF
--- a/components/ui/header.tsx
+++ b/components/ui/header.tsx
@@ -13,31 +13,13 @@ import ThemeSelector from "./theme-selector";
 import Link from "next/link";
 import { useTranslations } from "@/i18n";
 import { useCurrentLanguage } from "@/i18n/use-current-language";
-import { getGapWidth } from "@/lib/prevent-scrollbar-shift";
+import usePreventScroll from "@/hooks/usePreventScroll";
 
 export default function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
+  usePreventScroll({ isOpen: isMenuOpen });
   const t = useTranslations("header");
   const lang = useCurrentLanguage();
-
-  useEffect(() => {
-    if (isMenuOpen) {
-      const { gap } = getGapWidth("padding");
-      document.body.style.overflow = "hidden";
-      document.body.style.width = "100%";
-      document.body.style.paddingRight = `${gap}px`;
-    } else {
-      document.body.style.overflow = "";
-      document.body.style.width = "";
-      document.body.style.paddingRight = "";
-    }
-
-    return () => {
-      document.body.style.overflow = "";
-      document.body.style.width = "";
-      document.body.style.paddingRight = "";
-    };
-  }, [isMenuOpen]);
 
   const shouldShowIcon = (title: string) => {
     return ["Blog", "Github"].includes(title);

--- a/components/ui/header.tsx
+++ b/components/ui/header.tsx
@@ -13,6 +13,7 @@ import ThemeSelector from "./theme-selector";
 import Link from "next/link";
 import { useTranslations } from "@/i18n";
 import { useCurrentLanguage } from "@/i18n/use-current-language";
+import { getGapWidth } from "@/lib/prevent-scrollbar-shift";
 
 export default function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
@@ -21,12 +22,20 @@ export default function Header() {
 
   useEffect(() => {
     if (isMenuOpen) {
+      const { gap } = getGapWidth("padding");
       document.body.style.overflow = "hidden";
+      document.body.style.width = "100%";
+      document.body.style.paddingRight = `${gap}px`;
     } else {
-      document.body.style.overflow = "unset";
+      document.body.style.overflow = "";
+      document.body.style.width = "";
+      document.body.style.paddingRight = "";
     }
+
     return () => {
-      document.body.style.overflow = "unset";
+      document.body.style.overflow = "";
+      document.body.style.width = "";
+      document.body.style.paddingRight = "";
     };
   }, [isMenuOpen]);
 

--- a/hooks/usePreventScroll.ts
+++ b/hooks/usePreventScroll.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+import preventScroll from "@/lib/prevent-scrollbar";
+
+interface UsePreventScrollProps {
+  isOpen: boolean;
+}
+
+const usePreventScroll = ({ isOpen }: UsePreventScrollProps) => {
+  useEffect(() => {
+    preventScroll(isOpen);
+
+    return () => {
+      preventScroll(false);
+    };
+  }, [isOpen]);
+};
+
+export default usePreventScroll;

--- a/lib/prevent-scrollbar-shift.ts
+++ b/lib/prevent-scrollbar-shift.ts
@@ -1,0 +1,44 @@
+export type GapMode = "padding" | "margin";
+
+export interface GapOffset {
+  left: number;
+  top: number;
+  right: number;
+  gap: number;
+}
+
+export const zeroGap = {
+  left: 0,
+  top: 0,
+  right: 0,
+  gap: 0,
+};
+
+const parse = (x: string | null) => parseInt(x || "", 10) || 0;
+
+const getOffset = (gapMode: GapMode): number[] => {
+  const cs = window.getComputedStyle(document.body);
+
+  const left = cs[gapMode === "padding" ? "paddingLeft" : "marginLeft"];
+  const top = cs[gapMode === "padding" ? "paddingTop" : "marginTop"];
+  const right = cs[gapMode === "padding" ? "paddingRight" : "marginRight"];
+
+  return [parse(left), parse(top), parse(right)];
+};
+
+export const getGapWidth = (gapMode: GapMode = "margin"): GapOffset => {
+  if (typeof window === "undefined") {
+    return zeroGap;
+  }
+
+  const offsets = getOffset(gapMode);
+  const documentWidth = document.documentElement.clientWidth;
+  const windowWidth = window.innerWidth;
+
+  return {
+    left: offsets[0],
+    top: offsets[1],
+    right: offsets[2],
+    gap: Math.max(0, windowWidth - documentWidth + offsets[2] - offsets[0]),
+  };
+};

--- a/lib/prevent-scrollbar.ts
+++ b/lib/prevent-scrollbar.ts
@@ -1,13 +1,13 @@
-export type GapMode = "padding" | "margin";
+type GapMode = "padding" | "margin";
 
-export interface GapOffset {
+interface GapOffset {
   left: number;
   top: number;
   right: number;
   gap: number;
 }
 
-export const zeroGap = {
+const zeroGap = {
   left: 0,
   top: 0,
   right: 0,
@@ -26,7 +26,7 @@ const getOffset = (gapMode: GapMode): number[] => {
   return [parse(left), parse(top), parse(right)];
 };
 
-export const getGapWidth = (gapMode: GapMode = "margin"): GapOffset => {
+const getGapWidth = (gapMode: GapMode = "margin"): GapOffset => {
   if (typeof window === "undefined") {
     return zeroGap;
   }
@@ -42,3 +42,16 @@ export const getGapWidth = (gapMode: GapMode = "margin"): GapOffset => {
     gap: Math.max(0, windowWidth - documentWidth + offsets[2] - offsets[0]),
   };
 };
+
+const preventScroll = (isOpen: boolean) => {
+  if (isOpen) {
+    const { gap } = getGapWidth("padding");
+    document.body.style.overflow = "hidden";
+    document.body.style.paddingRight = `${gap}px`;
+  } else {
+    document.body.style.overflow = "";
+    document.body.style.paddingRight = "";
+  }
+};
+
+export default preventScroll;


### PR DESCRIPTION
### Description
- prevent scrolling when mobile menu open

### Review Point
- I'm having difficulty confirming because I don't see any layout shift on my screen.
- I will work on [the layout shift (width) issue when navigating to other pages](https://github.com/notionpresso/docs/pull/46) in the next PR.

### ScreenShot
<img width="370" alt="image" src="https://github.com/user-attachments/assets/c31669a5-f889-4207-8729-dc51f5facc9e">
