### PR TITLE
fix: duplicate markdown parsing

### DIFF
--- a/components/docs/docs-layout.tsx
+++ b/components/docs/docs-layout.tsx
@@ -4,6 +4,7 @@ import React, { useEffect } from "react";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import rehypeHighlight from "rehype-highlight";
+import remarkGfm from "remark-gfm";
 import "highlight.js/styles/github-dark.css"; // 다크 테마
 import {
   DynamicLayout,
@@ -72,6 +73,7 @@ export default function DocsLayout({
         </p>
         <ReactMarkdown
           className="prose prose-sm prose-block-code:bg-transparent sm:prose lg:prose-lg dark:prose-invert prose-headings:dark:text-white prose-p:dark:text-gray-300 prose-strong:dark:text-white prose-code:dark:text-white prose-ul:dark:text-gray-300 prose-ol:dark:text-gray-300"
+          remarkPlugins={[remarkGfm]}
           rehypePlugins={[rehypeRaw, rehypeHighlight]}
         >
           {content}

--- a/lib/mdx.ts
+++ b/lib/mdx.ts
@@ -3,9 +3,6 @@
 import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
-import { remark } from "remark";
-import html from "remark-html";
-import gfm from "remark-gfm";
 import { getGroupOrder, GroupId } from "@/constants/group";
 
 const contentDirectory = path.join(process.cwd(), "content", "guide");
@@ -46,14 +43,12 @@ function getAllDocumentsRecursive(dir: string, lang: string): Document[] {
       const fileContents = fs.readFileSync(entryPath, "utf8");
       const { data, content } = matter(fileContents);
       const groupOrder = getGroupOrder(data.group as GroupId);
-      const processedContent = remark().use(gfm).use(html).processSync(content);
-      const contentHtml = processedContent.toString();
 
       documents.push({
         slug: data.slug,
         title: data.title || "Untitled",
         group: data.group || "",
-        content: contentHtml,
+        content: content,
       });
     }
   });


### PR DESCRIPTION
## 🎯 Purpose of PR
fix: https://github.com/notionpresso/docs/issues/56

## 📸 Screenshots 
### desktop
| Before | After |
|--------|-------|
|![image](https://github.com/user-attachments/assets/c5fef9c8-7347-47e9-aa71-9e524036792e)|![image](https://github.com/user-attachments/assets/8568762d-23a1-4dfe-a0ac-759ca446a02b)|

### mobile
| Before | After |
|--------|-------|
|![image](https://github.com/user-attachments/assets/daf39bfa-9431-449c-b1f2-c33fd5806e2b)|![image](https://github.com/user-attachments/assets/ebca3e96-e92c-4d73-910a-d28ff6b4cb16)|

## What I did 
fix duplicate markdown parsing:  b0657b484519e2a48539aed014c8f18ad86c0da5

Let me write a clear PR message explaining the roles of these functions and the duplicate processing issue:

## Current Issue
Currently, we're processing markdown content twice by using both `remark()` with HTML conversion and `ReactMarkdown`, which creates unnecessary overhead.

### remark() with HTML Function Role
1. Parses markdown text into AST (Abstract Syntax Tree)
2. Processes GitHub Flavored Markdown via remark-gfm
3. Converts to HTML string via remark-html

Example:
```javascript
import { remark } from "remark";
import html from "remark-html";
import gfm from "remark-gfm";

remark()
  .use(gfm)
  .use(html)
  .processSync(content)
  // Internal process:
  // 1. Original markdown text
  // 2. Convert to AST
  // 3. Process GFM syntax
  // 4. Convert to HTML string
```

### ReactMarkdown Component Role
1. Takes markdown text and parses it (uses remark internally)
2. Processes GitHub Flavored Markdown with same gfm plugin
3. Converts directly to React components

Example:
```javascript
<ReactMarkdown remarkPlugins={[gfm]}>
  {content}
  // Internal process:
  // 1. Original markdown text
  // 2. Convert to AST using remark
  // 3. Process GFM syntax
  // 4. Convert directly to React components
</ReactMarkdown>
```

### Duplicate Processing
Current implementation:
```javascript
// This creates duplicate processing
const processedHtml = remark()
  .use(gfm)
  .use(html)
  .processSync(content)

<ReactMarkdown>{processedHtml}</ReactMarkdown>

// Processing sequence:
1. remark() processing
   - markdown → AST → HTML string (unnecessary step)

2. ReactMarkdown processing
   - HTML string → AST again → React components
```

## Solution
Remove the duplicate processing by using ReactMarkdown's built-in capabilities:

```javascript
<ReactMarkdown remarkPlugins={[gfm]}>
  {content}
</ReactMarkdown>
```

## Benefits
- Eliminated unnecessary HTML string generation step
- Removed duplicate AST parsing
- Direct conversion to React components
- Simplified processing pipeline
- Same GFM support with cleaner implementation
- Better integration with React's component model




## 📋 Review Guidelines
Reviews are prioritized using the following levels:

| Priority | Description | Response Expectation |
|----------|-------------|---------------------|
| P0-P2 | Critical issues | Must be resolved through implementation or discussion |
| P3 | Significant concerns needing clarification | Requires further discussion or context |
| P4-P5 | Minor suggestions | Can be addressed at author's discretion |

### Review Process
- P0-P2: If changes are not implemented, a discussion with the reviewer is required
- P3: Indicates important issues requiring more context or solution exploration
- P4-P5: Optional improvements that can be addressed at the author's discretion
