### PR TITLE
fix: fix typo at tutorial

### DIFF
--- a/content/tutorial/en/12ace18c-fd83-8071-b3a5-dd8d21da61cf.json
+++ b/content/tutorial/en/12ace18c-fd83-8071-b3a5-dd8d21da61cf.json
@@ -12300,7 +12300,7 @@
           {
             "type": "text",
             "text": {
-              "content": "// Install CLI\nnpm install -g @notionpress/cli\n\n// Copy Notion data to your project\nnpx npresso --page {{page-url}} --auth {{notion-api-key}}\n",
+              "content": "// Install CLI\nnpm install -g @notionpresso/cli\n\n// Copy Notion data to your project\nnpx npresso --page {{page-url}} --auth {{notion-api-key}}\n",
               "link": null
             },
             "annotations": {
@@ -12311,7 +12311,7 @@
               "code": false,
               "color": "default"
             },
-            "plain_text": "// Install CLI\nnpm install -g @notionpress/cli\n\n// Copy Notion data to your project\nnpx npresso --page {{page-url}} --auth {{notion-api-key}}\n",
+            "plain_text": "// Install CLI\nnpm install -g @notionpresso/cli\n\n// Copy Notion data to your project\nnpx npresso --page {{page-url}} --auth {{notion-api-key}}\n",
             "href": null
           }
         ],

--- a/content/tutorial/ko/126ce18c-fd83-80a5-8260-d757c56405b2.json
+++ b/content/tutorial/ko/126ce18c-fd83-80a5-8260-d757c56405b2.json
@@ -10351,7 +10351,7 @@
           {
             "type": "text",
             "text": {
-              "content": "// cli 설치\nnpm install -g @notionpress/cli\n\n// 노션 데이터 프로젝트에 복사하기\nnpx npresso --page {{페이지 주소}} --auth {{노션 api key}}",
+              "content": "// cli 설치\nnpm install -g @notionpresso/cli\n\n// 노션 데이터 프로젝트에 복사하기\nnpx npresso --page {{페이지 주소}} --auth {{노션 api key}}",
               "link": null
             },
             "annotations": {
@@ -10362,7 +10362,7 @@
               "code": false,
               "color": "default"
             },
-            "plain_text": "// cli 설치\nnpm install -g @notionpress/cli\n\n// 노션 데이터 프로젝트에 복사하기\nnpx npresso --page {{페이지 주소}} --auth {{노션 api key}}",
+            "plain_text": "// cli 설치\nnpm install -g @notionpresso/cli\n\n// 노션 데이터 프로젝트에 복사하기\nnpx npresso --page {{페이지 주소}} --auth {{노션 api key}}",
             "href": null
           }
         ],


### PR DESCRIPTION
### Description
- realted #63 
- fixed typo at tutorial `@notionpress/cli` to `@notionpresso/cli`